### PR TITLE
Add support for bold IRC formatting

### DIFF
--- a/src/compile.rb
+++ b/src/compile.rb
@@ -29,6 +29,7 @@ def compile_quotes_file(html_tpl, yaml_file)
         .gsub("{{ time }}", quote["created_at"].iso8601)
         .gsub("{{ deleted }}", (quote["deleted"] ? "true" : "false"))
         .gsub("{{ class-deleted }}", (quote["deleted"] ? "quote-status-deleted" : "quote-status-active"))
+        .gsub(/\x02(.*?)(\x02|\x0F|$)/,'<b>\1</b>')
 
   end
 


### PR DESCRIPTION
Matching \x02 (bold on IRC) paired with either another \x02, \x0F (reset
control chars) or end of line, will wrap its content in <b> and </b> to
make it bold.
